### PR TITLE
Added Binance API as Kafka producer

### DIFF
--- a/.factorypath
+++ b/.factorypath
@@ -161,7 +161,7 @@
     <factorypathentry kind="VARJAR" id="M2_REPO/org/scala-lang/scala-reflect/2.11.12/scala-reflect-2.11.12.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/com/typesafe/scala-logging/scala-logging_2.11/3.9.2/scala-logging_2.11-3.9.2.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/commons-cli/commons-cli/1.4/commons-cli-1.4.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-core/2.14.1/log4j-core-2.14.1.jar" enabled="true" runInBatchMode="false"/>
-    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-api/2.14.1/log4j-api-2.14.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar" enabled="true" runInBatchMode="false"/>
+    <factorypathentry kind="VARJAR" id="M2_REPO/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar" enabled="true" runInBatchMode="false"/>
     <factorypathentry kind="VARJAR" id="M2_REPO/org/slf4j/slf4j-log4j13/1.0.1/slf4j-log4j13-1.0.1.jar" enabled="true" runInBatchMode="false"/>
 </factorypath>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kafka streaming pub/sub system
 Project in which I attempted to build a Kafka pub/sub system with Spark and a database, all running using Docker Compose. Consists of:
-* Producer sending random ratings (between 1 and 5) to a Kafka topic
+* A Kafka producer which periodically retrieves recent trade information from the [Binance API](https://binance-docs.github.io/apidocs/spot/en/#recent-trades-list) (BTC-USDT).
 * Streaming Consumer using Apache Spark that counts rating occurences in batches
 
 ## Used software
@@ -19,7 +19,7 @@ mvn package assembly:single
 
 2. Start Docker Compose
 ```
-docker-compose up -d
+docker compose up -d --force-recreate
 ```
 
 ## Checking
@@ -38,5 +38,5 @@ docker logs data-challenge_spark-consumer_1 -f
 ## Stopping
 5. Stop Docker Compose
 ```
-docker-compose down
+docker compose down
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       APP_KAFKA_TOPIC: crypto
       APP_KAFKA_SERVER: kafka:9092
       APP_ZOOKEEPER_SERVER: zookeeper:2181
-      APP_PRODUCER_INTERVAL: 100
+      APP_PRODUCER_INTERVAL: 2500
 
   # spark-consumer:
   #   build: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "9094:9094"
     environment:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: netflix:1:1
+      KAFKA_CREATE_TOPICS: crypto:1:1
       KAFKA_ADVERTISED_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://127.0.0.1:9094
       KAFKA_LISTENERS: INTERNAL://kafka:9092,EXTERNAL://0.0.0.0:9094
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT
@@ -30,19 +30,19 @@ services:
       - kafka
     environment: 
       APP_GOAL: producer
-      APP_KAFKA_TOPIC: netflix
+      APP_KAFKA_TOPIC: crypto
       APP_KAFKA_SERVER: kafka:9092
       APP_ZOOKEEPER_SERVER: zookeeper:2181
       APP_PRODUCER_INTERVAL: 100
 
-  spark-consumer:
-    build: .
-    depends_on:
-      - kafka
-    ports:
-      - "4040:4040"
-    environment: 
-      APP_GOAL: consumer
-      APP_KAFKA_TOPIC: netflix
-      APP_KAFKA_SERVER: kafka:9092
-      APP_ZOOKEEPER_SERVER: zookeeper:2181
+  # spark-consumer:
+  #   build: .
+  #   depends_on:
+  #     - kafka
+  #   ports:
+  #     - "4040:4040"
+  #   environment: 
+  #     APP_GOAL: consumer
+  #     APP_KAFKA_TOPIC: netflix
+  #     APP_KAFKA_SERVER: kafka:9092
+  #     APP_ZOOKEEPER_SERVER: zookeeper:2181

--- a/src/main/java/com/danielvdhaak/App.java
+++ b/src/main/java/com/danielvdhaak/App.java
@@ -18,7 +18,7 @@ public class App
 
         switch (APP_GOAL.toLowerCase()) {
             case "producer":
-                KafkaProducerNetflix.main();
+                KafkaProducerCrypto.main();
                 break;
             case "consumer":
                 SparkConsumerNetflix.main();

--- a/src/main/java/com/danielvdhaak/Commons.java
+++ b/src/main/java/com/danielvdhaak/Commons.java
@@ -6,9 +6,9 @@ package com.danielvdhaak;
  */
 public class Commons {
     public final static String APP_KAFKA_TOPIC = System.getenv("APP_KAFKA_TOPIC") != null ?
-        System.getenv("APP_KAFKA_TOPIC") : "netflix";
+        System.getenv("APP_KAFKA_TOPIC") : "crypto";
     public final static String APP_KAFKA_SERVER = System.getenv("APP_KAFKA_SERVER") != null ?
-        System.getenv("APP_KAFKA_SERVER") : "localhost:9092";
+        System.getenv("APP_KAFKA_SERVER") : "localhost:9094";
     public final static String APP_ZOOKEEPER_SERVER = System.getenv("APP_ZOOKEEPER_SERVER") != null ?
         System.getenv("APP_ZOOKEEPER_SERVER") : "localhost:2181";
 }

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -15,7 +15,7 @@ import org.apache.commons.httpclient.methods.GetMethod;
 import org.apache.commons.httpclient.HttpException;
 
 public class KafkaProducerCrypto {
-    private static final Logger logger = LogManager.getLogger(KafkaProducerNetflix.class);
+    private static final Logger logger = LogManager.getLogger(KafkaProducerCrypto.class);
 
     public static void main(final String... args) 
     {

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -29,18 +29,6 @@ public class KafkaProducerCrypto {
         method = new GetMethod(url);
         method.setFollowRedirects(true);
 
-        // Convert to JSONObject
-        // String financialData = null;
-        // try {
-        //     JSONArray jsonArray = new JSONArray(responseBody);
-
-        //     financialData = jsonArray
-        //         .toString();
-        // } catch (JSONException e) {
-        //     logger.error(e.toString());
-        // }
-        // logger.info(financialData);
-
         // Initialize producer class
         final Producer<String, String> producer = createProducer();
         int EXAMPLE_PRODUCER_INTERVAL = System.getenv("APP_PRODUCER_INTERVAL") != null ?

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -48,6 +48,8 @@ public class KafkaProducerCrypto {
 
         try {
             while (true) {
+                long start = System.nanoTime();
+
                 // Get data from REST API
                 String responseBody = getHttpResponse(client, method, url);
 
@@ -59,7 +61,12 @@ public class KafkaProducerCrypto {
 
                 logger.debug("Sent record to topic {} @ {}.", metadata.topic(), metadata.timestamp());
 
-                Thread.sleep(EXAMPLE_PRODUCER_INTERVAL);
+                // Determine time to delay
+                float timeElapsed = ((float)(System.nanoTime() - start))*1e-6f;
+                int delay = EXAMPLE_PRODUCER_INTERVAL - (int)timeElapsed >= 0 ? 
+                    EXAMPLE_PRODUCER_INTERVAL - (int)timeElapsed : 0;
+                
+                Thread.sleep(delay);
             }
         } catch (InterruptedException | ExecutionException e) {
             logger.error("An error occurred.", e);

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -1,0 +1,108 @@
+package com.danielvdhaak;
+
+import java.io.*;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.kafka.clients.producer.*;
+import org.apache.kafka.common.serialization.StringSerializer;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.HttpException;
+
+public class KafkaProducerCrypto {
+    private static final Logger logger = LogManager.getLogger(KafkaProducerNetflix.class);
+
+    public static void main(final String... args) 
+    {
+        String url = "https://api.binance.com/api/v3/trades?symbol=BTCUSDT&limit=50";
+        
+        // Create singular HttpClient object
+        HttpClient client = createHttpClient(5000);
+
+        // Create GET method object
+        HttpMethod method = null;
+        method = new GetMethod(url);
+        method.setFollowRedirects(true);
+
+        // Convert to JSONObject
+        // String financialData = null;
+        // try {
+        //     JSONArray jsonArray = new JSONArray(responseBody);
+
+        //     financialData = jsonArray
+        //         .toString();
+        // } catch (JSONException e) {
+        //     logger.error(e.toString());
+        // }
+        // logger.info(financialData);
+
+        // Initialize producer class
+        final Producer<String, String> producer = createProducer();
+        int EXAMPLE_PRODUCER_INTERVAL = System.getenv("APP_PRODUCER_INTERVAL") != null ?
+                Integer.parseInt(System.getenv("APP_PRODUCER_INTERVAL")) : 100;
+
+        try {
+            while (true) {
+                // Get data from REST API
+                String responseBody = getHttpResponse(client, method, url);
+
+                // Publish producer record to Kafka topic
+                ProducerRecord<String, String> record = new ProducerRecord<>(
+                    Commons.APP_KAFKA_TOPIC,
+                    responseBody);
+                RecordMetadata metadata = producer.send(record).get();
+
+                logger.debug("Sent record to topic {} @ {}.", metadata.topic(), metadata.timestamp());
+
+                Thread.sleep(EXAMPLE_PRODUCER_INTERVAL);
+            }
+        } catch (InterruptedException | ExecutionException e) {
+            logger.error("An error occurred.", e);
+        } finally {
+            producer.flush();
+            producer.close();
+        }
+    }
+
+    private static Producer<String, String> createProducer() {
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Commons.APP_KAFKA_SERVER);
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, "KafkaProducerNetflix");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        return new KafkaProducer<>(props);
+    }
+
+    private static HttpClient createHttpClient(int timeout) {
+        HttpClient client = new HttpClient();
+
+        // Establish a connection with 5 seconds
+        client.getHttpConnectionManager().
+            getParams().setConnectionTimeout(timeout);
+
+        return client;
+    }
+
+    private static String getHttpResponse(HttpClient client, HttpMethod method, String url) {
+        // Retrieve response
+        String responseBody = null;
+        try {
+            client.executeMethod(method);
+            responseBody = method.getResponseBodyAsString();
+        } catch (HttpException he) {
+            logger.error("HTTP error connecting to '" + url + "'");
+            logger.error(he.getMessage());
+            System.exit(-4);
+        } catch (IOException ioe){
+            logger.error("Unable to connect to '" + url + "'");
+            System.exit(-3);
+        }
+
+        return responseBody;
+    }
+}


### PR DESCRIPTION
This PR introduces a new Kafka producer as I always intended it: using an API. It retrieves the 50 latest trades (*BTCUSDT*) from the [Binance API](https://binance-docs.github.io/apidocs/spot/en/#recent-trades-list) in fixed intervals (set by env var `APP_PRODUCER_INTERVAL`).
- Kafka producer `KafkaProducerCrypto.java` has been added
- `App.java` has been altered and now points to this class; `KafkaProducerNetflix.java` is now obsolete
- Documentation updated