### PR TITLE
Created HTTP utils class and unit tests

### DIFF
--- a/src/main/java/com/danielvdhaak/HttpUtils.java
+++ b/src/main/java/com/danielvdhaak/HttpUtils.java
@@ -45,6 +45,7 @@ public class HttpUtils {
      * @return the request object to be executed
      */
     public static HttpMethod createGetRequest(String url) {
+        // TODO: Implement other HTTP methods
         HttpMethod request = new GetMethod(url);
         request.setFollowRedirects(false);
 
@@ -74,11 +75,33 @@ public class HttpUtils {
             logger.error("HTTP error connecting to '" + url + "'");
             logger.error(he.getMessage());
             System.exit(-4);
-        } catch (IOException ioe){
+        } catch (IOException ioe) {
             logger.error("Unable to connect to '" + url + "'");
             System.exit(-3);
         }
 
         return request;
+    }
+
+    /**
+     * Parses the HTTP response body as a string.
+     * @param response HttpMethod object that has been executed
+     * @return HTTP response body in string format
+     */
+    public static String parseResponseBody(HttpMethod response) {
+        // Parse response body as string
+        String body = null;
+        try {
+            body = response.getResponseBodyAsString();
+        } catch (IOException e) {
+            logger.error("Error parsing response body: " + e.getMessage());
+        }
+
+        // Warn if the response body has no data
+        if (body == null || body.isEmpty()) {
+            logger.warn("No response body found!");
+        }
+
+        return body;
     }
 }

--- a/src/main/java/com/danielvdhaak/HttpUtils.java
+++ b/src/main/java/com/danielvdhaak/HttpUtils.java
@@ -38,4 +38,16 @@ public class HttpUtils {
 
         return client;
     }
+
+    /**
+     * Creates a HttpMethod object used to perform GET requests.
+     * @param url URL to send HTTP request to
+     * @return the request object to be executed
+     */
+    public static HttpMethod createGetRequest(String url) {
+        HttpMethod request = new GetMethod(url);
+        request.setFollowRedirects(false);
+
+        return request;
+    }
 }

--- a/src/main/java/com/danielvdhaak/HttpUtils.java
+++ b/src/main/java/com/danielvdhaak/HttpUtils.java
@@ -84,9 +84,9 @@ public class HttpUtils {
     }
 
     /**
-     * Parses the HTTP response body as a string.
+     * Parses the HTTP response body as a string. This does not handle empty responses.
      * @param response HttpMethod object that has been executed
-     * @return HTTP response body in string format
+     * @return HTTP response body in string format (can be empty/null)
      */
     public static String parseResponseBody(HttpMethod response) {
         // Parse response body as string
@@ -95,11 +95,6 @@ public class HttpUtils {
             body = response.getResponseBodyAsString();
         } catch (IOException e) {
             logger.error("Error parsing response body: " + e.getMessage());
-        }
-
-        // Warn if the response body has no data
-        if (body == null || body.isEmpty()) {
-            logger.warn("No response body found!");
         }
 
         return body;

--- a/src/main/java/com/danielvdhaak/HttpUtils.java
+++ b/src/main/java/com/danielvdhaak/HttpUtils.java
@@ -50,4 +50,35 @@ public class HttpUtils {
 
         return request;
     }
+
+    /**
+     * Performs an HTTP GET request to a given URL.
+     * @param client A HttpClient object
+     * @see createHttpCient()
+     * @param url The URL to send the request to
+     * @return The HTTP response
+     */
+    public static HttpMethod sendGetRequest(HttpClient client, String url) {
+        // Create request method
+        HttpMethod request = createGetRequest(url);
+
+        // Retrieve response (this populates the request object)
+        try {
+            client.executeMethod(request);
+
+            String status = request.getStatusText();
+            int code = request.getStatusCode();
+
+            logger.debug("[{}] {} ({})", code, status, url);
+        } catch (HttpException he) {
+            logger.error("HTTP error connecting to '" + url + "'");
+            logger.error(he.getMessage());
+            System.exit(-4);
+        } catch (IOException ioe){
+            logger.error("Unable to connect to '" + url + "'");
+            System.exit(-3);
+        }
+
+        return request;
+    }
 }

--- a/src/main/java/com/danielvdhaak/HttpUtils.java
+++ b/src/main/java/com/danielvdhaak/HttpUtils.java
@@ -1,0 +1,41 @@
+package com.danielvdhaak;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.methods.GetMethod;
+import org.apache.commons.httpclient.HttpException;
+
+/**
+ * <p>
+ * Utilities class containing util functions for making HTTP requests.
+ * </p>
+ * 
+ * @see org.apache.commons.httpclient
+ */
+public class HttpUtils {
+    private static final Logger logger = LogManager.getLogger(HttpUtils.class.getName());
+
+    /**
+     * Creates a client used to perform HTTP requests.
+     * @param timeout HTTP call timeout in milliseconds, cannot be negative.
+     * @return the HttpClient 
+     */
+    public static HttpClient createHttpClient(int timeout) {
+        HttpClient client = new HttpClient();
+
+        // Set connection timeout
+        if (timeout < 0) {
+            throw new IllegalArgumentException("Argument timeout cannot be negative");
+        }
+
+        client.getHttpConnectionManager().
+            getParams().setConnectionTimeout(timeout);
+
+        return client;
+    }
+}

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -14,25 +14,25 @@ import org.apache.commons.httpclient.HttpMethod;
 public class KafkaProducerCrypto {
     private static final Logger logger = LogManager.getLogger(KafkaProducerCrypto.class);
 
+    private static final int APP_PRODUCER_INTERVAL = System.getenv("APP_PRODUCER_INTERVAL") != null ?
+        Integer.parseInt(System.getenv("APP_PRODUCER_INTERVAL")) : 100;
+    private static final String APP_PRODUCER_API_ENDPOINT = System.getenv("APP_PRODUCER_API_ENDPOINT") != null ?
+        System.getenv("APP_PRODUCER_API_ENDPOINT") : "https://api.binance.com/api/v3/trades?symbol=BTCUSDT&limit=50";
+
     public static void main(final String... args) 
-    {
-        // Declare API endpoint
-        String url = "https://api.binance.com/api/v3/trades?symbol=BTCUSDT&limit=50";
-        
+    {        
         // Create singular HttpClient object
         HttpClient client = HttpUtils.createHttpClient(0);
 
         // Initialize producer class
         final Producer<String, String> producer = createProducer();
-        int EXAMPLE_PRODUCER_INTERVAL = System.getenv("APP_PRODUCER_INTERVAL") != null ?
-                Integer.parseInt(System.getenv("APP_PRODUCER_INTERVAL")) : 100;
 
         try {
             while (true) {
                 long start = System.nanoTime();
 
                 // Send GET request
-                HttpMethod response = HttpUtils.sendGetRequest(client, url);
+                HttpMethod response = HttpUtils.sendGetRequest(client, APP_PRODUCER_API_ENDPOINT);
                 String responseBody = HttpUtils.parseResponseBody(response);
 
                 // Skip on empty response body
@@ -51,8 +51,8 @@ public class KafkaProducerCrypto {
 
                 // Determine time to delay
                 float timeElapsed = ((float)(System.nanoTime() - start))*1e-6f;
-                int delay = EXAMPLE_PRODUCER_INTERVAL - (int)timeElapsed >= 0 ? 
-                    EXAMPLE_PRODUCER_INTERVAL - (int)timeElapsed : 0;
+                int delay = APP_PRODUCER_INTERVAL - (int)timeElapsed >= 0 ? 
+                    APP_PRODUCER_INTERVAL - (int)timeElapsed : 0;
                 
                 Thread.sleep(delay);
             }
@@ -67,7 +67,7 @@ public class KafkaProducerCrypto {
     private static Producer<String, String> createProducer() {
         Properties props = new Properties();
         props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, Commons.APP_KAFKA_SERVER);
-        props.put(ProducerConfig.CLIENT_ID_CONFIG, "KafkaProducerNetflix");
+        props.put(ProducerConfig.CLIENT_ID_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
         return new KafkaProducer<>(props);

--- a/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
+++ b/src/main/java/com/danielvdhaak/KafkaProducerCrypto.java
@@ -35,7 +35,11 @@ public class KafkaProducerCrypto {
                 HttpMethod response = HttpUtils.sendGetRequest(client, url);
                 String responseBody = HttpUtils.parseResponseBody(response);
 
-                // Continue on empty string?
+                // Skip on empty response body
+                if (responseBody == null || responseBody.isEmpty()) {
+                    logger.warn("No response body found!");
+                    continue;
+                }
 
                 // Publish producer record to Kafka topic
                 ProducerRecord<String, String> record = new ProducerRecord<>(

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="debug">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -44,7 +44,7 @@ public class HttpUtilsTest {
 
         HttpMethod response = HttpUtils.sendGetRequest(
             httpClient, 
-            "https://httpbin.org/get"
+            "https://api.binance.com/api/v3/ping"
         );
 
         assertEquals(response.getStatusCode(), 200);
@@ -59,6 +59,20 @@ public class HttpUtilsTest {
             httpClient, 
             "Not a URL"
         );
+    }
+
+    @Test
+    public void testResponseBodyParse() {
+        HttpClient httpClient = HttpUtils.createHttpClient(0);
+
+        HttpMethod response = HttpUtils.sendGetRequest(
+            httpClient, 
+            "https://api.binance.com/api/v3/ping"
+        );
+
+        String body = HttpUtils.parseResponseBody(response);
+        
+        assertEquals(body, "{}");
     }
 
 }

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -1,24 +1,14 @@
 package com.danielvdhaak;
 
 import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.instanceOf;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
+import org.apache.commons.httpclient.URIException;
 
 
 public class HttpUtilsTest {
-    
-    @Test
-    public void assertHttpClientType() {
-        Object httpClient = HttpUtils.createHttpClient(0);
-
-        assertThat(httpClient, instanceOf(HttpClient.class));
-    }
 
     @Test
     public void testHttpClientTimeout() {
@@ -33,14 +23,18 @@ public class HttpUtilsTest {
     }
 
     @Test
-    public void assertGetRequestType() {
-        HttpMethod httpMethod = HttpUtils.createGetRequest("null");
+    public void testRequestUrl() throws URIException {
+        String url = "https://api.binance.com/api/v3/ping";
+        HttpMethod request = HttpUtils.createGetRequest(url);
 
-        assertThat(httpMethod, instanceOf(HttpMethod.class));
+        assertEquals(request.getURI().toString(), url);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testBadRequestUrl() {
         HttpMethod httpMethod = HttpUtils.createGetRequest("Not a URL");
     }
+
+
+
 }

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -19,7 +19,7 @@ public class HttpUtilsTest {
     public void testHttpClientTimeout() {
         HttpClient httpClient = HttpUtils.createHttpClient(100);
 
-        assertEquals(httpClient.getHttpConnectionManager().getParams().getConnectionTimeout() ,100);
+        assertEquals(100, httpClient.getHttpConnectionManager().getParams().getConnectionTimeout());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -32,7 +32,7 @@ public class HttpUtilsTest {
         String url = API_PING_ENDPOINT;
         HttpMethod request = HttpUtils.createGetRequest(url);
 
-        assertEquals(request.getURI().toString(), url);
+        assertEquals(url, request.getURI().toString());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -49,7 +49,7 @@ public class HttpUtilsTest {
             API_PING_ENDPOINT
         );
 
-        assertEquals(response.getStatusCode(), 200);
+        assertEquals(200, response.getStatusCode());
         assertTrue(response.hasBeenUsed());
     }
 
@@ -74,7 +74,7 @@ public class HttpUtilsTest {
 
         String body = HttpUtils.parseResponseBody(response);
         
-        assertEquals(body, "{}");
+        assertEquals("{}", body);
     }
 
 }

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -13,6 +13,8 @@ import org.apache.commons.httpclient.URIException;
 
 public class HttpUtilsTest {
 
+    private static final String API_PING_ENDPOINT = "https://api.binance.com/api/v3/ping";
+
     @Test
     public void testHttpClientTimeout() {
         HttpClient httpClient = HttpUtils.createHttpClient(100);
@@ -27,7 +29,7 @@ public class HttpUtilsTest {
 
     @Test
     public void testRequestUrl() throws URIException {
-        String url = "https://api.binance.com/api/v3/ping";
+        String url = API_PING_ENDPOINT;
         HttpMethod request = HttpUtils.createGetRequest(url);
 
         assertEquals(request.getURI().toString(), url);
@@ -44,7 +46,7 @@ public class HttpUtilsTest {
 
         HttpMethod response = HttpUtils.sendGetRequest(
             httpClient, 
-            "https://api.binance.com/api/v3/ping"
+            API_PING_ENDPOINT
         );
 
         assertEquals(response.getStatusCode(), 200);
@@ -67,7 +69,7 @@ public class HttpUtilsTest {
 
         HttpMethod response = HttpUtils.sendGetRequest(
             httpClient, 
-            "https://api.binance.com/api/v3/ping"
+            API_PING_ENDPOINT
         );
 
         String body = HttpUtils.parseResponseBody(response);

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -1,0 +1,33 @@
+package com.danielvdhaak;
+
+import org.junit.Test;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+
+import org.apache.commons.httpclient.HttpClient;
+
+
+public class HttpUtilsTest {
+    
+    @Test
+    public void createSimpleHttpClient() {
+        Object httpClient = HttpUtils.createHttpClient(0);
+
+        assertThat(httpClient, instanceOf(HttpClient.class));
+    }
+
+    @Test
+    public void testHttpClientTimeout() {
+        HttpClient httpClient = HttpUtils.createHttpClient(100);
+
+        assertEquals(httpClient.getHttpConnectionManager().getParams().getConnectionTimeout() ,100);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testHttpClientNegativeTimeout() {
+        HttpClient httpClient = HttpUtils.createHttpClient(-100);
+    }
+}

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -2,6 +2,9 @@ package com.danielvdhaak;
 
 import org.junit.Test;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
 
 import org.apache.commons.httpclient.HttpClient;
 import org.apache.commons.httpclient.HttpMethod;
@@ -35,6 +38,27 @@ public class HttpUtilsTest {
         HttpMethod httpMethod = HttpUtils.createGetRequest("Not a URL");
     }
 
+    @Test
+    public void testGetRequest() throws IOException {
+        HttpClient httpClient = HttpUtils.createHttpClient(0);
 
+        HttpMethod response = HttpUtils.sendGetRequest(
+            httpClient, 
+            "https://httpbin.org/get"
+        );
+
+        assertEquals(response.getStatusCode(), 200);
+        assertTrue(response.hasBeenUsed());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadGetRequest() {
+        HttpClient httpClient = HttpUtils.createHttpClient(0);
+
+        HttpMethod response = HttpUtils.sendGetRequest(
+            httpClient, 
+            "Not a URL"
+        );
+    }
 
 }

--- a/src/test/java/com/danielvdhaak/HttpUtilsTest.java
+++ b/src/test/java/com/danielvdhaak/HttpUtilsTest.java
@@ -8,12 +8,13 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.HttpMethod;
 
 
 public class HttpUtilsTest {
     
     @Test
-    public void createSimpleHttpClient() {
+    public void assertHttpClientType() {
         Object httpClient = HttpUtils.createHttpClient(0);
 
         assertThat(httpClient, instanceOf(HttpClient.class));
@@ -29,5 +30,17 @@ public class HttpUtilsTest {
     @Test(expected = IllegalArgumentException.class)
     public void testHttpClientNegativeTimeout() {
         HttpClient httpClient = HttpUtils.createHttpClient(-100);
+    }
+
+    @Test
+    public void assertGetRequestType() {
+        HttpMethod httpMethod = HttpUtils.createGetRequest("null");
+
+        assertThat(httpMethod, instanceOf(HttpMethod.class));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testBadRequestUrl() {
+        HttpMethod httpMethod = HttpUtils.createGetRequest("Not a URL");
     }
 }


### PR DESCRIPTION
This PR features a code migration of HTTP request-related functions to a separate utils class.
- Created class `HttpUtils()` with four methods
  - `createHttpClient()`
  - `createGetRequest()`
  - `sendGetRequest()`
  - `parseResponseBody()`
- Added unit tests for these methods
- Implemented `HttpUtils()` in the producer class `KafkaProducerCrypto()`
- Parameterised some configuration constants
- Changed overall logging level from INFO to DEBUG